### PR TITLE
PEP 8 style guide fixes

### DIFF
--- a/DFG.py
+++ b/DFG.py
@@ -1,59 +1,63 @@
-DEBUG_LEVEL=1
+DEBUG_LEVEL = 1
 
-Keys = [(0,0),(1,0),(0,1),(1,1)]
+Keys = [(0, 0), (1, 0), (0, 1), (1, 1)]
 
-dicProd = { (0,0):
-    {(0,0): (0,0), (1,0): (0,0), (0,1): (0,0), (1,1): (0,0)},
-        (1,0):
-            {(0,0): (0,0), (1,0): (1,0), (0,1): (0,1), (1,1): (1,1)},
-            (0,1):
-                {(0,0): (0,0), (1,0): (0,1), (0,1): (0,1), (1,1): (0,1)},
-            (1,1):
-                {(0,0): (0,0), (1,0): (1,1), (0,1): (0,1), (1,1): (1,1)}
-}
+dicProd = {(0, 0):
+               {(0, 0): (0, 0), (1, 0): (0, 0), (0, 1): (0, 0), (1, 1): (0, 0)},
+           (1, 0):
+               {(0, 0): (0, 0), (1, 0): (1, 0), (0, 1): (0, 1), (1, 1): (1, 1)},
+           (0, 1):
+               {(0, 0): (0, 0), (1, 0): (0, 1), (0, 1): (0, 1), (1, 1): (0, 1)},
+           (1, 1):
+               {(0, 0): (0, 0), (1, 0): (1, 1), (0, 1): (0, 1), (1, 1): (1, 1)}
+           }
 
-dicSum = { (0,0):
-    {(0,0): (0,0), (1,0): (1,0), (0,1): (0,1), (1,1): (1,1)},
-        (1,0):
-            {(0,0): (1,0), (1,0): (1,0), (0,1): (1,1), (1,1): (1,1)},
-            (0,1):
-                {(0,0): (0,1), (1,0): (1,1), (0,1): (0,1), (1,1): (1,1)},
-            (1,1):
-                {(0,0): (1,1), (1,0): (1,1), (0,1): (1,1), (1,1): (1,1)}
-}
+dicSum = {(0, 0):
+              {(0, 0): (0, 0), (1, 0): (1, 0), (0, 1): (0, 1), (1, 1): (1, 1)},
+          (1, 0):
+              {(0, 0): (1, 0), (1, 0): (1, 0), (0, 1): (1, 1), (1, 1): (1, 1)},
+          (0, 1):
+              {(0, 0): (0, 1), (1, 0): (1, 1), (0, 1): (0, 1), (1, 1): (1, 1)},
+          (1, 1):
+              {(0, 0): (1, 1), (1, 0): (1, 1), (0, 1): (1, 1), (1, 1): (1, 1)}
+          }
 
-def Prod(a,b):
+
+def Prod(a, b):
     return dicProd[a][b]
 
-def Sum(a,b):
+
+def Sum(a, b):
     return dicSum[a][b]
 
-Zero = (0,0)
 
-Unit = (1,0)
+Zero = (0, 0)
+
+Unit = (1, 0)
 
 
-
-def MatProd(M1,M2,prod=Prod,sum=Sum,zero=Zero):
-    res=[]
+def MatProd(M1, M2, prod=Prod, sum=Sum, zero=Zero):
+    res = []
     for i in range(len(M1)):
         res.append([])
         for j in range(len(M2)):
             new = zero
             for k in range(len(M1)):
-                new = sum(new,prod(M1[i][k],M2[k][j]))
+                new = sum(new, prod(M1[i][k], M2[k][j]))
             res[i].append(new)
     return res
 
-def MatSum(M1,M2,sum=Sum):
-    res=[]
+
+def MatSum(M1, M2, sum=Sum):
+    res = []
     for i in range(len(M1)):
         res.append([])
         for j in range(len(M1)):
-            res[i].append(sum(M1[i][j],M2[i][j]))
+            res[i].append(sum(M1[i][j], M2[i][j]))
     return res
 
-def initMatrix(len,zero=Zero):
+
+def initMatrix(len, zero=Zero):
     res = []
     for i in range(len):
         res.append([])
@@ -61,15 +65,16 @@ def initMatrix(len,zero=Zero):
             res[i].append(zero)
     return res
 
-def extendMatrix(Mat,range_ext,zero=Zero,unit=Unit):
+
+def extendMatrix(Mat, range_ext, zero=Zero, unit=Unit):
     res = []
     for i in range(range_ext):
         res.append([])
         for j in range(range_ext):
-            if i<len(Mat) and j<len(Mat):
+            if i < len(Mat) and j < len(Mat):
                 res[i].append(Mat[i][j])
             else:
-                if i==j:
+                if i == j:
                     res[i].append(unit)
                 else:
                     res[i].append(zero)
@@ -80,245 +85,267 @@ def printMatrix(Mat):
     for i in range(len(Mat)):
         line = ""
         for j in range(len(Mat)):
-            line = line+"   "+str(Mat[i][j])
+            line = line + "   " + str(Mat[i][j])
         print(line)
     return 0
 
+
 def printRel(Rel):
-    if DEBUG_LEVEL>=2:
+    if DEBUG_LEVEL >= 2:
         print("DEBUG_LEVEL Information, printRel.")
         print(Rel[0])
         print(Rel[1])
     for i in range(len(Rel[1])):
-        line = str(Rel[0][i])+"   |   "
+        line = str(Rel[0][i]) + "   |   "
         for j in range(len(Rel[1])):
-            line = line+"   "+str(Rel[1][i][j])
+            line = line + "   " + str(Rel[1][i][j])
         print(line)
     return 0
 
-def is_empty(Rel):
-    if Rel[0]==[]:
+
+def is_empty(relation):
+    if not relation[0]:
         return True
-    if Rel[1]==[]:
+    if not relation[1]:
         return True
     return False
 
-def homogeneisation(R1,R2,zero=Zero,unit=Unit): # Relations are tuples (v,M) of a list of variables and a matrix
+
+def homogeneisation(relation_1, relation_2, zero=Zero, unit=Unit):
+    """
+    :param relation_1: Tuple (v,M) of a list of variables and a matrix
+    :param relation_2: Tuple (v,M) of a list of variables and a matrix
+    :param zero:
+    :param unit:
+    :return:
+    """
     var_indices = []
     var2 = []
-    if is_empty(R1):
-        empty=Relation(R2[0])
+    if is_empty(relation_1):
+        empty = Relation(relation_2[0])
         empty.identity()
-        return((empty.variables,empty.matrix),R2)
-    if is_empty(R2):
-        empty=Relation(R1[0])
+        return (empty.variables, empty.matrix), relation_2
+    if is_empty(relation_2):
+        empty = Relation(relation_1[0])
         empty.identity()
-        return(R1,(empty.variables,empty.matrix))
-    if DEBUG_LEVEL>=2:
+        return relation_1, (empty.variables, empty.matrix)
+    if DEBUG_LEVEL >= 2:
         print("DEBUG_LEVEL info for Homogeneisation. Inputs.")
-        printRel(R1)
-        printRel(R2)
-    for v in R2[0]:
+        printRel(relation_1)
+        printRel(relation_2)
+    for v in relation_2[0]:
         var2.append(v)
-    for v in R1[0]:
+    for v in relation_1[0]:
         found = False
-        for j in range(len(R2[0])):
-            if R2[0][j]==v:
+        for j in range(len(relation_2[0])):
+            if relation_2[0][j] == v:
                 var_indices.append(j)
                 found = True
                 var2.remove(v)
         if not found:
             var_indices.append(-1)
     for v in var2:
-        var_indices.append(R2[0].index(v))
-    var_extended=R1[0]+var2
-    M1_extended=extendMatrix(R1[1],len(var_extended))
-    M2_extended = []
+        var_indices.append(relation_2[0].index(v))
+    var_extended = relation_1[0] + var2
+    m1_extended = extendMatrix(relation_1[1], len(var_extended))
+    m2_extended = []
     for i in range(len(var_extended)):
-        M2_extended.append([])
-        i_in = var_indices[i]!=-1
+        m2_extended.append([])
+        i_in = var_indices[i] != -1
         for j in range(len(var_extended)):
-            if not i_in and i==j:
-                M2_extended[i].append(unit)
-            elif i_in and var_indices[j]!=-1:
-                M2_extended[i].append(R2[1][var_indices[i]][var_indices[j]])
+            if not i_in and i == j:
+                m2_extended[i].append(unit)
+            elif i_in and var_indices[j] != -1:
+                m2_extended[i].append(relation_2[1][var_indices[i]][var_indices[j]])
             else:
-                M2_extended[i].append(zero)
-    if DEBUG_LEVEL>=2:
+                m2_extended[i].append(zero)
+    if DEBUG_LEVEL >= 2:
         print("DEBUG_LEVEL info for Homogeneisation. Result.")
-        printRel(R1)
-        printRel(R2)
-        printRel((var_extended,M1_extended))
-        printRel((var_extended,M2_extended))
-    return ((var_extended,M1_extended),(var_extended,M2_extended))
+        printRel(relation_1)
+        printRel(relation_2)
+        printRel((var_extended, m1_extended))
+        printRel((var_extended, m2_extended))
+    return (var_extended, m1_extended), (var_extended, m2_extended)
 
 
-def compositionRelations(R1,R2):
-    (eR1,eR2)=homogeneisation(R1,R2)
-    Result=(eR1[0],MatProd(eR1[1],eR2[1]))
-    if DEBUG_LEVEL>=2:
+def compositionRelations(R1, R2):
+    (eR1, eR2) = homogeneisation(R1, R2)
+    result = (eR1[0], MatProd(eR1[1], eR2[1]))
+    if DEBUG_LEVEL >= 2:
         print("DEBUG_LEVEL info for compositionRelations. Inputs.")
         printRel(R1)
         printRel(R2)
         print("DEBUG_LEVEL info for compositionRelations. Outputs.")
-        printRel(Result)
-    return Result
+        printRel(result)
+    return result
 
-def sumRelations(R1,R2):
-    (eR1,eR2)=homogeneisation(R1,R2)
-    return (eR1[0],MatSum(eR1[1],eR2[1]))
 
-def Out_Rel(R,zero=Zero,unit=Unit):
-    out_tab=[]
+def sumRelations(R1, R2):
+    (eR1, eR2) = homogeneisation(R1, R2)
+    return eR1[0], MatSum(eR1[1], eR2[1])
+
+
+def Out_Rel(R, zero=Zero, unit=Unit):
+    out_tab = []
     for i in range(len(R[1])):
-        empty=True
-        ended=False
-        j=0
-        while (not ended) and j<len(R[1]):
-            if R[1][j][i]!=zero:
-                empty=False
-            if R[1][j][i]!=unit and R[1][j][i]!=zero:
+        empty = True
+        ended = False
+        j = 0
+        while (not ended) and j < len(R[1]):
+            if R[1][j][i] != zero:
+                empty = False
+            if R[1][j][i] != unit and R[1][j][i] != zero:
                 out_tab.append(R[0][i])
-                ended=True
-            if DEBUG_LEVEL>=2:
+                ended = True
+            if DEBUG_LEVEL >= 2:
                 print("Out_rel")
                 printRel(R)
-                print(i,j,"coef.",R[1][j][i],"ended",ended,"empty",empty)
-            j=j+1
+                print(i, j, "coef.", R[1][j][i], "ended", ended, "empty", empty)
+            j = j + 1
         if empty and not ended:
             out_tab.append(R[0][i])
-    if DEBUG_LEVEL>=2:
+    if DEBUG_LEVEL >= 2:
         print(out_tab)
         print("==========")
     return out_tab
 
-def In_Rel(R,zero=Zero,unit=Unit):
-    in_tab=[]
+
+def In_Rel(R, zero=Zero, unit=Unit):
+    in_tab = []
     for i in range(len(R[1])):
-        empty=True
-        j=0
-        while empty and j<len(R[1]):
-            if R[1][i][j]!=zero and R[1][i][j]!=unit:
-                empty=False
+        empty = True
+        j = 0
+        while empty and j < len(R[1]):
+            if R[1][i][j] != zero and R[1][i][j] != unit:
+                empty = False
                 in_tab.append(R[0][i])
-            j=j+1
+            j = j + 1
     return in_tab
 
-def In_Out_Rel(R,zero=Zero,unit=Unit):
-    return (In_Rel(R,zero),Out_Rel(R,zero,unit))
+
+def In_Out_Rel(R, zero=Zero, unit=Unit):
+    return In_Rel(R, zero), Out_Rel(R, zero, unit)
 
 
-def isequalRel(R1,R2):
-    if set(R1[0])!=set(R2[0]):
+def isequalRel(R1, R2):
+    if set(R1[0]) != set(R2[0]):
         return False
-    (eR1,eR2)=homogeneisation(R1,R2)
+    (eR1, eR2) = homogeneisation(R1, R2)
     for i in range(len(eR1[1])):
         for j in range(len(eR1[1])):
-            if eR1[1][i][j]!=eR2[1][i][j]:
+            if eR1[1][i][j] != eR2[1][i][j]:
                 return False
     return True
 
-def identityRel(var,unit=Unit,zero=Zero):
-    Id=[]
+
+def identityRel(var, unit=Unit, zero=Zero):
+    Id = []
     for i in range(len(var)):
         Id.append([])
         for j in range(len(var)):
-            if i==j:
+            if i == j:
                 Id[i].append(unit)
             else:
                 Id[i].append(zero)
-    return (var,Id)
+    return var, Id
 
-def algebraicRel(Rel,list,zero=Zero,strongDep=(0,1)):
-    (Var,Mat)=Rel
+
+def algebraicRel(relation, list, zero=Zero, strongDep=(0, 1)):
+    (Var, Mat) = relation
     out = Var.index(list[0][0])
-    Mat[out][out]=zero
+    Mat[out][out] = zero
     for var in list[1]:
-        in_ind=Var.index(var)
-        Mat[in_ind][out]=strongDep
-    return (Var,Mat)
+        in_ind = Var.index(var)
+        Mat[in_ind][out] = strongDep
+    return Var, Mat
 
-def conditionRel(condvar,outvar,zero=Zero,strongDep=(0,1)):
-    Var=list(set(condvar)|set(outvar))
-    Mat=[]
-    for i in range(len(Var)):
-        Mat.append([])
-        for j in range(len(Var)):
-            Mat[i].append(zero)
-    for i in range(len(Var)):
-        for j in range(len(Var)):
-            if Var[i] in condvar and Var[j] in outvar:
-                Mat[i][j]=strongDep
-    return (Var,Mat)
+
+def conditionRel(condvar, outvar, zero=Zero, strongDep=(0, 1)):
+    var = list(set(condvar) | set(outvar))
+    matrix = []
+    for i in range(len(var)):
+        matrix.append([])
+        for j in range(len(var)):
+            matrix[i].append(zero)
+    for i in range(len(var)):
+        for j in range(len(var)):
+            if var[i] in condvar and var[j] in outvar:
+                matrix[i][j] = strongDep
+    return var, matrix
+
 
 class Relation():
-    def __init__(self,variables):
+    def __init__(self, variables):
         self.variables = variables
         self.matrix = initMatrix(len(variables))
-    
-    def algebraic(self,list): # list contains two list with left-hand and right-hand side variables respectively; they are supposed to be
-        # contained in self.variables already.
-        (Var,Mat)=algebraicRel((self.variables,self.matrix),list)
+
+    def algebraic(self, list):
+        """
+        :param list: list contains two list with left-hand and right-hand side variables respectively;
+            they are supposed to be contained in self.variables already.
+        """
+
+        (Var, Mat) = algebraicRel((self.variables, self.matrix), list)
         self.matrix = Mat
         return self
-    
+
     def identity(self):
-        (Var,Mat)=identityRel(self.variables)
-        self.matrix=Mat
+        (Var, Mat) = identityRel(self.variables)
+        self.matrix = Mat
         return self
-    
-    def conditionRel(self,list_var):
-        (Var,Mat)=conditionRel(list_var,self.out())
-        (V,M)=sumRelations((self.variables,self.matrix),(Var,Mat))
+
+    def conditionRel(self, list_var):
+        (Var, Mat) = conditionRel(list_var, self.out())
+        (V, M) = sumRelations((self.variables, self.matrix), (Var, Mat))
         cond = Relation(V)
         cond.matrix = M
         return cond
-    
-    def composition(self,Rel):
-        (var,Mat)=compositionRelations((self.variables,self.matrix),(Rel.variables,Rel.matrix))
+
+    def composition(self, rel):
+        (var, Mat) = compositionRelations((self.variables, self.matrix), (rel.variables, rel.matrix))
         compo = Relation(var)
         compo.matrix = Mat
         return compo
-    
-    def sumRel(self,Rel):
-        (var,Mat)=sumRelations((self.variables,self.matrix),(Rel.variables,Rel.matrix))
+
+    def sumRel(self, rel):
+        (var, Mat) = sumRelations((self.variables, self.matrix), (rel.variables, rel.matrix))
         result = Relation(var)
         result.matrix = Mat
         return result
-    
+
     def show(self):
-        printRel((self.variables,self.matrix))
-    
+        printRel((self.variables, self.matrix))
+
     def out(self):
-        return Out_Rel((self.variables,self.matrix))
-    
+        return Out_Rel((self.variables, self.matrix))
+
     def In(self):
-        return In_Rel((self.variables,self.matrix))
-    
+        return In_Rel((self.variables, self.matrix))
+
     def in_out(self):
-        return In_Out_Rel((self.variables,self.matrix))
-    
-    def equal(self,Rel):
-        return isequalRel((self.variables,self.matrix),(Rel.variables,Rel.matrix))
-    
+        return In_Out_Rel((self.variables, self.matrix))
+
+    def equal(self, rel):
+        return isequalRel((self.variables, self.matrix), (rel.variables, rel.matrix))
+
     def fixpoint(self):
         end = False
-        (v,M) = identityRel(self.variables)
-        Fix = Relation(v)
-        PreviousFix = Relation(v)
-        Current = Relation(v)
-        Fix.matrix=M
-        PreviousFix.matrix=M
-        Current.matrix=M
+        (v, M) = identityRel(self.variables)
+        fix = Relation(v)
+        previous_fix = Relation(v)
+        current = Relation(v)
+        fix.matrix = M
+        previous_fix.matrix = M
+        current.matrix = M
         while not end:
-            PreviousFix.matrix=Fix.matrix
-            Current = Current.composition(self)
-            Fix = Fix.sumRel(Current)
-            if Fix.equal(PreviousFix):
-                end=True
-            if DEBUG_LEVEL>=2:
+            previous_fix.matrix = fix.matrix
+            current = current.composition(self)
+            fix = fix.sumRel(current)
+            if fix.equal(previous_fix):
+                end = True
+            if DEBUG_LEVEL >= 2:
                 print("DEBUG. Fixpoint.")
                 print("DEBUG. Fixpoint.")
                 self.show()
-                Fix.show()
-        return Fix
+                fix.show()
+        return fix

--- a/LQICM.py
+++ b/LQICM.py
@@ -44,7 +44,7 @@ class LoopVisitor:
 def convert(node):
     loop_node = node.loop_node
     parent_index = node.parent[1]  # index in the AST of the original loop
-    node.parent[0].block_items.pop(parent_index)  # remove the orignal loop from AST
+    node.parent[0].block_items.pop(parent_index)  # remove the original loop from AST
     body = []  # list of new AST nodes for each peel
     original_body = []
     if loop_node.stmt.block_items is not None:

--- a/LQICM.py
+++ b/LQICM.py
@@ -7,17 +7,21 @@ from dependency import compute_dependencies
 
 sys.path.extend([".", ".."])
 
+
 class Loop:
     """This class defines a Loop object """
+
     def __init__(self, loop_node, parent, is_opt, inner_loops):
-        """ Initilize attributes for Loop """
-        self.loop_node = loop_node #the AST node of the loop being optimized
-        self.parent = parent # tuple(node of parent, index of the command)
-        self.is_opt = is_opt #whether loop is optimized or not
-        self.inner_loops = inner_loops #list of nested loops
+        """ Initialize attributes for Loop """
+        self.loop_node = loop_node  # the AST node of the loop being optimized
+        self.parent = parent  # tuple(node of parent, index of the command)
+        self.is_opt = is_opt  # whether loop is optimized or not
+        self.inner_loops = inner_loops  # list of nested loops
+
 
 class LoopVisitor:
     """This class is used for visiting c_ast nodes to find and store Loops"""
+
     def __init__(self):
         self.values = []
 
@@ -36,47 +40,53 @@ class LoopVisitor:
         if isinstance(node, (c_ast.DoWhile, c_ast.For)):
             convert(loop)
 
-def convert(node): 
+
+def convert(node):
     loop_node = node.loop_node
-    parent_index = node.parent[1] #index in the AST of the original loop
-    node.parent[0].block_items.pop(parent_index) #remove the orignal loop from AST
-    body = [] #list of new AST nodes for each peel 
+    parent_index = node.parent[1]  # index in the AST of the original loop
+    node.parent[0].block_items.pop(parent_index)  # remove the orignal loop from AST
+    body = []  # list of new AST nodes for each peel
     original_body = []
     if loop_node.stmt.block_items is not None:
-        original_body = loop_node.stmt.block_items 
+        original_body = loop_node.stmt.block_items
     if isinstance(loop_node, c_ast.For):
         if loop_node.init is not None:
-            body.append(loop_node.init.decls[0]) #add the initilization of the loop var before the loop 
+            body.append(loop_node.init.decls[0])  # add the initialization of the loop var before the loop
         if loop_node.next is not None:
-            loop_node.stmt = c_ast.Compound(original_body + [loop_node.next]) #add the inc/dec of the loop var at the end of the body 
-        body.append(c_ast.While(loop_node.cond, loop_node.stmt)) 
-    if isinstance(loop_node, c_ast.DoWhile):#if loop is a DoWhile, add the commands of the first peel outside of the loop
-        for i in original_body: #add each command to the modified AST
+            loop_node.stmt = c_ast.Compound(
+                original_body + [loop_node.next])  # add the inc/dec of the loop var at the end of the body
+        body.append(c_ast.While(loop_node.cond, loop_node.stmt))
+    if isinstance(loop_node,
+                  c_ast.DoWhile):  # if loop is a DoWhile, add the commands of the first peel outside of the loop
+        for i in original_body:  # add each command to the modified AST
             body.append(i)
-        body.append(c_ast.While(loop_node.cond, c_ast.Compound(original_body)))       
-    for i in body: #add new nodes to the modified AST
+        body.append(c_ast.While(loop_node.cond, c_ast.Compound(original_body)))
+    for i in body:  # add new nodes to the modified AST
         node.parent[0].block_items.insert(parent_index, i)
         parent_index = parent_index + 1
-    node.parent = (node.parent[0],parent_index-1) #update the parent
+    node.parent = (node.parent[0], parent_index - 1)  # update the parent
+
 
 def opt(loop):
     """Finds the inner-most loop that can be optimized and peels it """
     for inner_loop in loop.inner_loops:
         if not inner_loop.is_opt:
-            opt(inner_loop) #optimize the inner loop if it has not been opimized yet
-    (graph, list_deg) = compute_dependencies(loop.loop_node.stmt.block_items) #compute the dependencies of the loop
-    loop_peel(graph, list_deg, loop) #peel the loop based on its dependencies
-    return(graph, list_deg)
+            opt(inner_loop)  # optimize the inner loop if it has not been opimized yet
+    (graph, list_deg) = compute_dependencies(loop.loop_node.stmt.block_items)  # compute the dependencies of the loop
+    loop_peel(graph, list_deg, loop)  # peel the loop based on its dependencies
+    return graph, list_deg
+
 
 def visit_ast(ast):
     """Creates a LoopVisitor object to find the loops in a program """
     loop_visit = LoopVisitor()
     loop_visit.visit(ast)
-    return loop_visit.values #list of all the outer-most loops in a program
+    return loop_visit.values  # list of all the outer-most loops in a program
+
 
 def optimize(filename):
     """ Parses the file and modifies the AST"""
-    ast = parse_file(filename, use_cpp=True, cpp_path="gcc", cpp_args=['-E'])  #replace cpp with gcc to remove comments
+    ast = parse_file(filename, use_cpp=True, cpp_path="gcc", cpp_args=['-E'])  # replace cpp with gcc to remove comments
     loops = visit_ast(ast)
     deps = []
     for i in range(len(loops)):
@@ -88,9 +98,11 @@ def optimize(filename):
         print(format(newast), file=text_file)
     return deps
 
+
 if __name__ == "__main__":
-    if len(sys.argv)> 1:
+    if len(sys.argv) > 1:
         optimize(sys.argv[1])
     else:
         import doctest
+
         doctest.testfile("test_examples.txt")

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ quasi-invariant inner loop.
 
 This uses the [pycparser](https://github.com/eliben/pycparser).
 
+Install project dependencies by running the following command:
+
+```text
+python -m pip install -r requirements.txt
+```
+
+
 ## Installation 
 
 Install [pycparser](https://github.com/eliben/pycparser).

--- a/dependency.py
+++ b/dependency.py
@@ -1,6 +1,7 @@
 from pycparser import c_ast
 from relation import compute_rel
 
+
 def compute_dependencies(loop_body):
     """Add list of dependencies for each command in the loop """
     graph = []
@@ -8,30 +9,32 @@ def compute_dependencies(loop_body):
     lldep = []
     list_deg = []
     if loop_body is not None:
-        if outer_break(loop_body): #if the loop contains an outer break
+        if outer_break(loop_body):  # if the loop contains an outer break
             for command in loop_body:
-                rels_n = compute_rel(command) #compute relation for each command in loop
-                if isinstance(command,(c_ast.Break)):
+                rels_n = compute_rel(command)  # compute relation for each command in loop
+                if isinstance(command, c_ast.Break):
                     tab_in_out.append(rels_n.in_out())
                 else:
-                    source = [] #remove the soucre dependencies
-                    target = rels_n.in_out()[1] #keep the modified variable
-                    tab_in_out.append((source,target))
+                    source = []  # remove the source dependencies
+                    target = rels_n.in_out()[1]  # keep the modified variable
+                    tab_in_out.append((source, target))
         else:
             for command in loop_body:
-                rels_n = compute_rel(command) #compute relation for command in loop
-                tab_in_out.append(rels_n.in_out()) #add tuple ([source vars],[target vars])  
+                rels_n = compute_rel(command)  # compute relation for command in loop
+                tab_in_out.append(rels_n.in_out())  # add tuple ([source vars],[target vars])
         for index in range(len(loop_body)):
-            lldep.append(primary_dependency(tab_in_out, index, graph, loop_body))# add list of indicies of the primary dependencies
-        list_deg = compute_list_deg(lldep, loop_body) #compute list of invariance degree using dependencies
+            lldep.append(primary_dependency(tab_in_out, index, graph,
+                                            loop_body))  # add list of indicies of the primary dependencies
+        list_deg = compute_list_deg(lldep, loop_body)  # compute list of invariance degree using dependencies
         graph.sort()
-    return (graph, list_deg)
+    return graph, list_deg
+
 
 def primary_dependency(tab_in_out, target_index, graph, loop_body):
     """Find the primary dependencies for the command at target_index"""
     list_dep = []
     source_vars = tab_in_out[target_index][0]
-    for var in source_vars:  #for each source var in the command
+    for var in source_vars:  # for each source var in the command
         found = False
         k = 0
         # find the primary dependency for the var
@@ -39,37 +42,41 @@ def primary_dependency(tab_in_out, target_index, graph, loop_body):
             source_index = target_index - k - 1
             if source_index < 0:
                 source_index = len(tab_in_out) + target_index - k - 1
-            if var in tab_in_out[source_index][1]: #if var is modified by the command
+            if var in tab_in_out[source_index][1]:  # if var is modified by the command
                 if not isinstance(loop_body[source_index], (c_ast.While, c_ast.If)):
                     found = True
-                if not( isinstance(loop_body[source_index], c_ast.If) and "Break()" in tab_in_out[source_index][1]): #if the dependency is not an if statement that contains a break
-                    graph.append((source_index, target_index, var))#add the dependency to the graph
-                    list_dep.append(source_index)# add index of the commands
+                if not (isinstance(loop_body[source_index], c_ast.If) and "Break()" in tab_in_out[source_index][
+                    1]):  # if the dependency is not an if statement that contains a break
+                    graph.append((source_index, target_index, var))  # add the dependency to the graph
+                    list_dep.append(source_index)  # add index of the commands
             k = k + 1
     return list_dep
+
 
 def compute_list_deg(lldep, loop_body):
     """Compute the invariance degrees for all the commands in a loop"""
     list_deg = init_tab_deg(loop_body)
     for i in range(0, len(loop_body)):
-        if list_deg[i] != -1: #if the command can be peeled
-            compute_deg(list_deg, i, lldep)  #calculate the degree of the command
+        if list_deg[i] != -1:  # if the command can be peeled
+            compute_deg(list_deg, i, lldep)  # calculate the degree of the command
     return list_deg
 
+
 def init_tab_deg(loop_body):
-    """" Initilize the list of invariance degrees """
+    """" Initialize the list of invariance degrees """
     list_deg = []
     for command in loop_body:
-        if isinstance(command, (c_ast.FuncCall)): #if the command cannot be removed set degree to -1
+        if isinstance(command, c_ast.FuncCall):  # if the command cannot be removed set degree to -1
             list_deg.append(-1)
         else:
-            list_deg.append(0) #set degree to 0 for all other commands
+            list_deg.append(0)  # set degree to 0 for all other commands
     return list_deg
+
 
 def compute_deg(tab_deg, index, lldep):
     """Computes dependency degree of a given command """
     if tab_deg[index] == 0:  # if deg has not been computed
-        if len(lldep[index]) == 0: # if the command has no dependencies, set deg to 1
+        if len(lldep[index]) == 0:  # if the command has no dependencies, set deg to 1
             tab_deg[index] = 1
         else:  # else compute max degree of the commands dependencies
             tab_deg[index] = -1
@@ -85,6 +92,7 @@ def compute_deg(tab_deg, index, lldep):
                     deg = tab_deg[l] + 1
             tab_deg[index] = deg  # set deg of the command to the max degree
     return tab_deg[index]
+
 
 def outer_break(loop):
     """Check if the while loop contains a break"""

--- a/peel.py
+++ b/peel.py
@@ -2,68 +2,79 @@
 from pycparser import c_ast
 
 NVIND = -1
+
+
 def new_var():
     global NVIND
-    NVIND=NVIND+1
-    return "å"+str(NVIND)
+    NVIND = NVIND + 1
+    return "å" + str(NVIND)
+
 
 def loop_peel(graph, list_deg, loop):
     """Peel the loop based on the maximum invariance degree"""
     peeling_deg = max_deg_of_list(list_deg) + 1
-    if peeling_deg != 0: #if loop can be peeled
+    if peeling_deg != 0:  # if loop can be peeled
         loop_node = loop.loop_node
-        parent_index = loop.parent[1] #index in the AST of the original loop
-        loop.parent[0].block_items.pop(parent_index) #remove the orignal loop from AST
-        commands = init_commands(peeling_deg, loop_node.stmt.block_items) #initialize all the commands in the body of the loop
-        peel = [] #list of AST nodes for each peel
+        parent_index = loop.parent[1]  # index in the AST of the original loop
+        loop.parent[0].block_items.pop(parent_index)  # remove the orignal loop from AST
+        commands = init_commands(peeling_deg,
+                                 loop_node.stmt.block_items)  # initialize all the commands in the body of the loop
+        peel = []  # list of AST nodes for each peel
         for i in range(peeling_deg):
-            peel_body = [] #list of commands for current peel
+            peel_body = []  # list of commands for current peel
             for (node, ind) in commands[i]:
-                if  ind != -1 and list_deg[ind] == i + 1: #if the command can be peeled and has reached its peeling degree
+                # if the command can be peeled and has reached its peeling degree
+                if ind != -1 and list_deg[ind] == i + 1:
                     (capture_tab, recover_tab) = captures(ind, loop_node.stmt.block_items, list_deg, graph)
-                    add_newvars(commands, i, node, ind, peeling_deg, capture_tab, recover_tab)
+                    add_new_vars(commands, i, node, ind, peeling_deg, capture_tab, recover_tab)
                 peel_body.append(node)
 
-            if i == peeling_deg - 1: #if its the last peel, add the body to a while statement with the same cond exp as the original while loop
+            # if its the last peel, add the body to a while statement with the same cond exp as the original while loop
+            if i == peeling_deg - 1:
                 peel.append(c_ast.While(loop_node.cond, c_ast.Compound(peel_body)))
-            else: #if not last peel, add the body to an if statement with the same cond exp as the original while loop
+            else:  # if not last peel, add the body to an if statement with the same cond exp as the original while loop
                 peel.append(c_ast.If(loop_node.cond, c_ast.Compound(peel_body), None))
-                
-        if check_break(loop_node.stmt):  #if the loop contains a break/contiue, wrap the entire peeled loop inside of a while loop with the same cond exp as the original
+
+        # if the loop contains a break/contiue, wrap the entire peeled loop inside of a while loop with the same cond
+        # exp as the original
+        if check_break(loop_node.stmt):
             peel = c_ast.While(loop_node.cond, c_ast.Compound(peel + [c_ast.Break()]), None)
             loop.parent[0].block_items.insert(parent_index, peel)
         else:
-            for i in peel: #add each peel to the modified AST
+            for i in peel:  # add each peel to the modified AST
                 loop.parent[0].block_items.insert(parent_index, i)
                 parent_index = parent_index + 1
 
     loop.isOpt = True
 
-def add_newvars(commands, i, node, ind, peeling_deg, capture_tab, recover_tab):
+
+def add_new_vars(commands, i, node, ind, peeling_deg, capture_tab, recover_tab):
     """Add capture and recover nodes and remove the command from all future peels """
     new_ind = commands[i].index((node, ind))
     for (new_node, deg) in capture_tab:
         if deg == -1 or deg > i + 1:
             for k in range(len(new_node)):
-                commands[i].insert(new_ind+1, (new_node[k], -1))
+                commands[i].insert(new_ind + 1, (new_node[k], -1))
 
-    for j in range(i+1, peeling_deg):
+    for j in range(i + 1, peeling_deg):
         new_ind = commands[j].index((node, ind))
         for (new_node, deg) in recover_tab:
             if deg == -1 or deg > j:
-                commands[j].insert(new_ind+ 1, (new_node[0], -1))
+                commands[j].insert(new_ind + 1, (new_node[0], -1))
         commands[j].pop(new_ind)
 
+
 def captures(index, while_body, list_deg, graph):
-    """Check if the command being peeled is a source and creates new nodes to store the variabless value"""
+    """Check if the command being peeled is a source and creates new nodes to store the variables value"""
     capture_tab = []
     recover_tab = []
     var_out = is_source(index, graph, list_deg)
     for (var, deg_max) in var_out:
-        new_vars = [new_var(), new_var()] #create two unique variable names
+        new_vars = [new_var(), new_var()]  # create two unique variable names
         capture_tab.append((create_capture_node(new_vars, var, index, while_body), deg_max))
         recover_tab.append((create_recover_node(new_vars, var, index, while_body), deg_max))
     return (capture_tab, recover_tab)
+
 
 def is_source(cur_ind, graph, list_deg):
     """Check if the variable modified in the current command is used as a source for any other command in the loop """
@@ -83,6 +94,7 @@ def is_source(cur_ind, graph, list_deg):
             var_out.append((used_var, deg_max))
     return var_out
 
+
 def create_capture_node(new_vars, var, index, while_body):
     """Create an assignment capture node (new_vars = var)"""
     tab = []
@@ -91,12 +103,14 @@ def create_capture_node(new_vars, var, index, while_body):
     tab.append(c_ast.Assignment("=", c_ast.ID(new_vars[0]), c_ast.ID(var)))
     return tab
 
+
 def create_recover_node(new_vars, var, index, while_body):
     """Create an assignment recovery node (var = new_var) """
     new_node = c_ast.Assignment("=", c_ast.ID(var), c_ast.ID(new_vars[0]))
     if isinstance(while_body[index], (c_ast.While, c_ast.If)):
         new_node = c_ast.If(c_ast.ID(new_vars[1]), c_ast.Compound([new_node]), None)
     return [new_node]
+
 
 def check_break(node):
     """Check if the while loop comtains a break or continue """
@@ -109,6 +123,7 @@ def check_break(node):
                     return True
     return False
 
+
 def max_deg_of_list(list_deg):
     """Compute max invariance degree of all the commands """
     deg = -1
@@ -116,6 +131,7 @@ def max_deg_of_list(list_deg):
         if com_deg >= deg:
             deg = com_deg
     return deg
+
 
 def init_commands(peeling_deg, block_items):
     """ Initialize the commands in the body of the loop
@@ -125,11 +141,11 @@ def init_commands(peeling_deg, block_items):
     commands = []
     index = 0
     for i in range(peeling_deg):
-        commands.append([]) #each list added corresponds to a 'peel' in a loop
+        commands.append([])  # each list added corresponds to a 'peel' in a loop
     if block_items is not None:
         for node in block_items:
             for i in range(peeling_deg):
-                commands[i].append((node, index)) #each tuple (node,i) contains the AST node and the corresponding index
+                commands[i].append(
+                    (node, index))  # each tuple (node,i) contains the AST node and the corresponding index
             index = index + 1
     return commands
- 

--- a/relation.py
+++ b/relation.py
@@ -1,19 +1,22 @@
 from pycparser import c_ast
 from DFG import Relation
 
+
 class VarVisitor(c_ast.NodeVisitor):
     """This class finds all the variables in a command """
+
     def __init__(self):
-        self.values = [] #list of variable names used in command
+        self.values = []  # list of variable names used in command
 
     def visit_ID(self, command):
         """Add variable name to list of values"""
         self.values.append(command.name)
 
+
 def compute_rel(command, cond_var=[]):
     """Compose and create Relation depending on the type of command """
     if isinstance(command, c_ast.Assignment):
-        rel = compute_command(command.lvalue.name,command.rvalue, cond_var)
+        rel = compute_command(command.lvalue.name, command.rvalue, cond_var)
     elif isinstance(command, c_ast.Decl):
         if command.init is None:
             rel = compute_command(command.type.declname, [], cond_var)
@@ -23,63 +26,71 @@ def compute_rel(command, cond_var=[]):
         var = list_var(command)
         rel = strong_dep_rel(var, var, var)
     elif isinstance(command, c_ast.If):
-        cond_var = list_var(command.cond) #get the variable in the conditional expression
-        rel_true = compute_branch(command.iftrue, cond_var) #compute the Relation of the 'then' and 'else' branch
+        cond_var = list_var(command.cond)  # get the variable in the conditional expression
+        rel_true = compute_branch(command.iftrue, cond_var)  # compute the Relation of the 'then' and 'else' branch
         rel_false = compute_branch(command.iffalse, cond_var)
         rel = rel_false.sumRel(rel_true)
-        rel = rel.conditionRel(cond_var) #add conditional dependency
+        rel = rel.conditionRel(cond_var)  # add conditional dependency
     elif isinstance(command, (c_ast.DoWhile, c_ast.While, c_ast.For)):
         rel = compute_loop(command)
     elif isinstance(command, c_ast.Break):
-        target_var = [str(command)] 
-        rel = strong_dep_rel(cond_var + target_var, target_var, cond_var)#set a strong dependency between the source (and possible vars in the condition) to the target variable
+        target_var = [str(command)]
+        # set a strong dependency between the source (and possible vars in the condition) to the target variable
+        rel = strong_dep_rel(cond_var + target_var, target_var, cond_var)
     else:
         rel = Relation([])
     return rel
 
+
 def compute_command(target, sources, cond_var):
-    target_var = list(target) #variable being assigned to
+    target_var = list(target)  # variable being assigned to
     source_vars = list(set(list_var(sources)))
-    lvars = list(set(target_var) | set(source_vars)| set(cond_var)) #remove repeat variable names
-    return strong_dep_rel(lvars, target_var, source_vars + cond_var)#set a strong dependency between the source (and possible vars in the condition) to the target variable
+    lvars = list(set(target_var) | set(source_vars) | set(cond_var))  # remove repeat variable names
+    # set a strong dependency between the source (and possible vars in the condition) to the target variable
+    return strong_dep_rel(lvars, target_var, source_vars + cond_var)
+
 
 def compute_branch(branch_command, cond_var):
     """ Creates Relation for branch commands (iftrue/iffalse)"""
     rel = Relation([])
-    if branch_command is not None and branch_command.block_items is not None:  #check if the command exists and if the body is not empty
-        rel = compose_rel(branch_command, cond_var) #compose the Relation for each command in the body
+    # check if the command exists and if the body is not empty
+    if branch_command is not None and branch_command.block_items is not None:
+        rel = compose_rel(branch_command, cond_var)  # compose the Relation for each command in the body
     return rel
 
+
 def compute_loop(command):
-    rel = Relation([])
     cond_var = list_var(command.cond)
     if command.stmt.block_items is None or command.stmt.block_items == []:
         rel = Relation([""])
     else:
-        rel = compose_rel(command.stmt, cond_var) #compose the Relations for each command in the body
+        rel = compose_rel(command.stmt, cond_var)  # compose the Relations for each command in the body
         rel = rel.fixpoint()
     rel = rel.conditionRel(cond_var)
     return rel
+
 
 def compose_rel(command, cond_var):
     """ Creates Relation for a sequence of commands"""
     rel = Relation([])
     for child in command.block_items:
-        if isinstance(child, (c_ast.Break)): 
+        if isinstance(child, c_ast.Break):
             rel = rel.composition(compute_rel(child, cond_var))
-            return rel #stop computing the sequence once a break is reached 
-        elif isinstance(child, (c_ast.Continue)):
+            return rel  # stop computing the sequence once a break is reached
+        elif isinstance(child, c_ast.Continue):
             rel_c = Relation([child]).identity()
             return rel.composition(rel_c)
         else:
-            rel = rel.composition(compute_rel(child, cond_var)) # compute and compose the Relation for the child
+            rel = rel.composition(compute_rel(child, cond_var))  # compute and compose the Relation for the child
     return rel
+
 
 def list_var(command):
     """Return list of variable name in a command """
     var_visit = VarVisitor()
     var_visit.visit(command)
     return var_visit.values
+
 
 def strong_dep_rel(var, target_vars, source_vars):
     """Create a Relation and add strong dependencies between source and target variables"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pycparser


### PR DESCRIPTION
[PEP 8](https://www.python.org/dev/peps/pep-0008/) is Python language style guide. 

The changes proposed in this PR are in reference to this style guide to improve the readability of the code.

### Summary of changes

#### [Use of whitespace/blank lines](https://www.python.org/dev/peps/pep-0008/#blank-lines) 

Applied general reformatting of files and added blank lines between top-level functions

#### [Naming](https://www.python.org/dev/peps/pep-0008/#naming-conventions) 

Increased use of lowercase variable names when appropriate. 

`DFG.py` has several functions that use PascalCase but I have left them as-is in case there are references to them in the research paper, in which case that would be the preferred style. 

I also noticed reuse of variable names that shadow built-in functions (e.g. `list` or `sum`) ([example 1](https://github.com/ThomasRuby/LQICM_On_C_Toy_Parser/blob/9757574629b76610b495b236e5923c492127f500/DFG.py#L232), [example 2](https://github.com/ThomasRuby/LQICM_On_C_Toy_Parser/blob/9757574629b76610b495b236e5923c492127f500/DFG.py#L37)). This should generally be avoided. Two ways to avoid this are: using a more descriptive name or using single trailing underscore (`list_` or `sum_`) which adds clarity so as not to be confused with built-in `list` or `sum`.

#### [Max line length](https://www.python.org/dev/peps/pep-0008/#maximum-line-length)

Inline comments tend to extend beyond the recommendation in which case I have moved some of them on the preceding line, before the actual command. Maintaining this max length is helpful when opening multiple files side by side. This picture should demonstrate this idea. This is a minor issue since using soft wraps in the editor helps.

<img width="1461" alt="Screen Shot 2021-01-05 at 11 33 33 PM" src="https://user-images.githubusercontent.com/2580981/103729461-80476b00-4fae-11eb-9750-1600e942c231.png">



